### PR TITLE
Update PermissionFragment.java

### DIFF
--- a/library/src/main/java/com/hjq/permissions/PermissionFragment.java
+++ b/library/src/main/java/com/hjq/permissions/PermissionFragment.java
@@ -53,7 +53,7 @@ public final class PermissionFragment extends Fragment implements Runnable {
     public void prepareRequest(Activity activity, OnPermission call) {
         // 将当前的请求码和对象添加到集合中
         sContainer.put(getArguments().getInt(REQUEST_CODE), call);
-        activity.getFragmentManager().beginTransaction().add(this, activity.getClass().getName()).commit();
+        activity.getFragmentManager().beginTransaction().add(this, activity.getClass().getName()).commitAllowingStateLoss();
     }
 
     @Override


### PR DESCRIPTION
 commit方法可能在Activity的onSaveInstanceState()之后调用，会导致“java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState”报错，修改为commitAllowingStateLoss（）方法