### PR TITLE
fix:修复部分设备跳转权限页崩溃的问题

### DIFF
--- a/library/src/main/java/com/hjq/permissions/PermissionFragment.java
+++ b/library/src/main/java/com/hjq/permissions/PermissionFragment.java
@@ -218,8 +218,8 @@ public final class PermissionFragment extends Fragment implements Runnable {
                     continue;
                 }
                 // 跳转到特殊权限授权页面
-                startActivityForResult(PermissionSettingPage.getSmartPermissionIntent(activity,
-                        PermissionUtils.asArrayList(permission)), getArguments().getInt(REQUEST_CODE));
+                PermissionUtils.startActivityForResult(PermissionSettingPage.getSmartPermissionIntent(activity,
+                        PermissionUtils.asArrayList(permission)), getArguments().getInt(REQUEST_CODE),activity);
                 requestSpecialPermission = true;
             }
         }

--- a/library/src/main/java/com/hjq/permissions/PermissionUtils.java
+++ b/library/src/main/java/com/hjq/permissions/PermissionUtils.java
@@ -6,6 +6,7 @@ import android.app.AppOpsManager;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
@@ -731,6 +732,14 @@ final class PermissionUtils {
             case Surface.ROTATION_90:
             default:
                 return false;
+        }
+    }
+
+    static void startActivityForResult(Intent intent, int requestCode, Activity mContext) {
+        try {
+            mContext.startActivityForResult(intent, requestCode);
+        }catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/library/src/main/java/com/hjq/permissions/XXPermissions.java
+++ b/library/src/main/java/com/hjq/permissions/XXPermissions.java
@@ -304,7 +304,7 @@ public final class XXPermissions {
      * @param requestCode           Activity 跳转请求码
      */
     public static void startPermissionActivity(Activity activity, List<String> permissions, int requestCode) {
-        activity.startActivityForResult(PermissionSettingPage.getSmartPermissionIntent(activity, permissions), requestCode);
+        PermissionUtils.startActivityForResult(PermissionSettingPage.getSmartPermissionIntent(activity, permissions), requestCode,activity);
     }
 
     /* android.app.Fragment */
@@ -336,7 +336,7 @@ public final class XXPermissions {
         if (activity == null) {
             return;
         }
-        fragment.startActivityForResult(PermissionSettingPage.getSmartPermissionIntent(activity, permissions), requestCode);
+        PermissionUtils.startActivityForResult(PermissionSettingPage.getSmartPermissionIntent(activity, permissions), requestCode,activity);
     }
 
     /* android.support.v4.app.Fragment */
@@ -368,6 +368,6 @@ public final class XXPermissions {
         if (activity == null) {
             return;
         }
-        fragment.startActivityForResult(PermissionSettingPage.getSmartPermissionIntent(activity, permissions), requestCode);
+        PermissionUtils.startActivityForResult(PermissionSettingPage.getSmartPermissionIntent(activity, permissions), requestCode,activity);
     }
 }


### PR DESCRIPTION
轮子哥 你好
我们公司面向的可能不仅仅是手机 也有可能是电视 车机 而我观测线上数据有很多都是跳转到权限页发生的崩溃
所以我在项目使用的13.2的版本基础上增加了trycatch防护用以解决这个问题
希望采纳
祝好